### PR TITLE
feat: set codesign for targets by product type or key

### DIFF
--- a/pbx.ts
+++ b/pbx.ts
@@ -52,6 +52,7 @@ export class DocumentObject {
     get buildConfigurationsList(): XCConfigurationList {
         return this.document[this.ast.value.get("buildConfigurationList").text];
     }
+    get productType() { return this.ast.value.get("productType").text; }
 }
 
 @pbx export class XCBuildConfiguration extends DocumentObject {


### PR DESCRIPTION
Add functionality to set target code signing by productType and target key.